### PR TITLE
Elasticsearch-Kibana docker-compose

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,0 +1,15 @@
+## Setup
+* Configure parameters in elasticsearch.yml, kibana can be custom configured similarly.
+* `docker-compose up` to spin elasticsearch and kibana docker containers.
+
+## default authentication:
+* elasticsearch.username: elastic
+* elasticsearch.password: changeme
+
+## Elasticsearch
+* https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+
+## Kibana
+* https://www.elastic.co/guide/en/kibana/current/_configuring_kibana_on_docker.html
+

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -2,7 +2,7 @@
 * Configure parameters in elasticsearch.yml, kibana can be custom configured similarly.
 * `docker-compose up` to spin elasticsearch and kibana docker containers.
 
-## default authentication:
+## Docker image default authentication values
 * elasticsearch.username: elastic
 * elasticsearch.password: changeme
 

--- a/elasticsearch/docker-compose.yml
+++ b/elasticsearch/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+services:
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:5.3.1
+    container_name: kibana
+    ports:
+      - "0.0.0.0:5601:5601"
+  
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.3.1
+    container_name: elasticsearch
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    links:
+      - kibana
+    volumes:
+      - ./elasticsearch.yml:/usr/share/elasticsearch/elasticsearch.yml
+    ports:
+      - "0.0.0.0:9200:9200"

--- a/elasticsearch/elasticsearch.yml
+++ b/elasticsearch/elasticsearch.yml
@@ -1,0 +1,6 @@
+indices.query.bool.max_clause_count: 5000
+network.host: 0.0.0.0
+script.engine.groovy.inline.update: true
+script.engine.groovy.inline.aggs: true
+action.auto_create_index: false
+transport.host: localhost


### PR DESCRIPTION
docker hub images deprecated - https://hub.docker.com/_/elasticsearch/

Elastic.co docker image to be used - https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html